### PR TITLE
Option to disable EPEL repo installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Role Variables
   - If the release repository shall be enabled (default: `false`)
 - `opencast_repository_enabled_testing`
   - If the testing repository shall be enabled (default: `false`)
+- `opencast_repository_enable_epel`
+  - Opencast uses some dependencies from EPEL RPM repository.
+    Here you can enable (value: `true`) or disable (value: `false`) installation of the
+    `epel-release` package (default: `true`). On RedHat installation with Satellite this
+    property can be handy. On Debian based systems this property do nothing.
 - `opencast_repository_identifiers:`
   - List of RPM repository identifiers.
   - This variable is not actually used in this role but can be used by other roles to temporarily activate the repository.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 opencast_repository_enabled_testing: false
 opencast_repository_enabled_release: false
+opencast_repository_enable_epel: true
 opencast_repository_identifiers:
   - opencast-noarch
   - opencast-x86_64

--- a/tasks/rhel.yml
+++ b/tasks/rhel.yml
@@ -32,3 +32,4 @@
 - name: Install epel repository
   ansible.builtin.package:
     name: epel-release
+  when: opencast_repository_enable_epel | bool


### PR DESCRIPTION
Opencast uses some dependencies from EPEL RPM repository. This Ansible Galaxy role installs epel-release package, which defines the EPEL repository. Some RedHat systems use Satellite, in which case defining the EPEL repository should be skipped.