### PR TITLE
Fixed apt cache update

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,0 @@
----
-- name: Update apt cache
-  ansible.builtin.apt:
-    update_cache: true

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -12,7 +12,7 @@
     state: present
 
 - name: Remove orphan opencast package repository definition
-  notify: Update apt cache
+  register: rm_orphan_repo
   ansible.builtin.apt_repository:
     repo: >-
       deb https://pkg.opencast.org/debian
@@ -22,7 +22,7 @@
     state: absent
 
 - name: Install the opencast package repository
-  notify: Update apt cache
+  register: add_oc_repo
   ansible.builtin.apt_repository:
     repo: >-
       deb https://pkg.opencast.org/debian
@@ -33,7 +33,7 @@
     state: "{{ 'present' if opencast_repository_enabled_release | bool else 'absent' }}"
 
 - name: Install the opencast testing package repository
-  notify: Update apt cache
+  register: add_oc_testing_repo
   ansible.builtin.apt_repository:
     repo: >-
       deb https://pkg.opencast.org/debian
@@ -42,3 +42,11 @@
     filename: opencast
     # yamllint disable-line rule:line-length
     state: "{{ 'present' if opencast_repository_enabled_testing | bool else 'absent' }}"
+
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+  when: >
+    rm_orphan_repo is changed or
+    add_oc_repo is changed or
+    add_oc_testing_repo is changed


### PR DESCRIPTION
Apt cache update was triggered by a notify. A notify handler is running at the end of the Ansible block. As this role is used as dependency for other roles (like `elan.opencast_elasticsearch`), the trigger will run to late.

Example:

```Ansible
- name: Deploy Elasticsearch
  hosts: elasticsearch
  roles:
    - elan.opencast_elasticsearch <-- The packages are located in an Opencast repository
                                      that is unknown on a clean system. Without an apt update
                                      performed so far, the role will fail.
    <-- triggers would run here
```

Apt cache should be updated by this role and not by others.